### PR TITLE
Disable import of pkg_resources for Python 3.3+

### DIFF
--- a/src/infi/__init__.py
+++ b/src/infi/__init__.py
@@ -1,3 +1,3 @@
 import sys
-if sys.hexversion < 0x30300f0:
+if sys.version_info < (3,3,0):
     __import__("pkg_resources").declare_namespace(__name__)

--- a/src/infi/__init__.py
+++ b/src/infi/__init__.py
@@ -1,1 +1,3 @@
-__import__("pkg_resources").declare_namespace(__name__)
+import sys
+if hex(sys.hexversion) < '0x30300f0':
+    __import__("pkg_resources").declare_namespace(__name__)

--- a/src/infi/systray/__init__.py
+++ b/src/infi/systray/__init__.py
@@ -1,2 +1,4 @@
-__import__("pkg_resources").declare_namespace(__name__)
+import sys
+if hex(sys.hexversion) < '0x30300f0':
+    __import__("pkg_resources").declare_namespace(__name__)
 from .traybar import SysTrayIcon

--- a/src/infi/systray/__init__.py
+++ b/src/infi/systray/__init__.py
@@ -1,4 +1,4 @@
 import sys
-if sys.hexversion < 0x30300f0:
+if sys.version_info < (3,3,0):
     __import__("pkg_resources").declare_namespace(__name__)
 from .traybar import SysTrayIcon


### PR DESCRIPTION
_I created a new pull request because of issues with my first fork._

--------------

```
__import__("pkg_resources").declare_namespace(__name__)
```

is deprecated in Python 3.3+ and causes issues with pyinstaller (mainly having to import the entire pkg_resources package, which is quite large). So checking the version number and not doing the import for these versions is likely the best solution to keep Python 2.x compatibility.

I have tested this in Python 3.6.5 and everything works as expected with this patch.