### PR TITLE
Allow menu options to be updatable

### DIFF
--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -37,12 +37,7 @@ class SysTrayIcon(object):
         self._hover_text = hover_text
         self._on_quit = on_quit
 
-        menu_options = menu_options or ()
-        menu_options = menu_options + (('Quit', None, SysTrayIcon.QUIT),)
-        self._next_action_id = SysTrayIcon.FIRST_ID
-        self._menu_actions_by_id = set()
-        self._menu_options = self._add_ids_to_menu_options(list(menu_options))
-        self._menu_actions_by_id = dict(self._menu_actions_by_id)
+        self._set_menu_options(menu_options)
 
         window_class_name = window_class_name or ("SysTrayIconPy-%s" % (str(uuid.uuid4())))
 
@@ -122,14 +117,29 @@ class SysTrayIcon(object):
         PostMessage(self._hwnd, WM_CLOSE, 0, 0)
         self._message_loop_thread.join()
 
-    def update(self, icon=None, hover_text=None):
-        """ update icon image and/or hover text """
+    def update(self, icon=None, hover_text=None, menu_options=None):
+        """ update icon image and/or hover text and/or menu options """
+        icon_refresh_needed = False
         if icon:
             self._icon = icon
             self._load_icon()
+            icon_refresh_needed = True
         if hover_text:
             self._hover_text = hover_text
-        self._refresh_icon()
+            icon_refresh_needed = True
+        if icon_refresh_needed:
+            self._refresh_icon()
+        if menu_options:
+            self._set_menu_options(menu_options)
+
+    def _set_menu_options(self, menu_options):
+        menu_options = menu_options or ()
+        menu_options = menu_options + (('Quit', None, SysTrayIcon.QUIT),)
+        self._next_action_id = SysTrayIcon.FIRST_ID
+        self._menu_actions_by_id = set()
+        self._menu_options = self._add_ids_to_menu_options(list(menu_options))
+        self._menu_actions_by_id = dict(self._menu_actions_by_id)
+        self._menu = None
 
     def _add_ids_to_menu_options(self, menu_options):
         result = []

--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -133,6 +133,8 @@ class SysTrayIcon(object):
             self._set_menu_options(menu_options)
 
     def _set_menu_options(self, menu_options):
+        if self._menu is not None:
+            DestroyMenu(self._menu)
         menu_options = menu_options or ()
         menu_options = menu_options + (('Quit', None, SysTrayIcon.QUIT),)
         self._next_action_id = SysTrayIcon.FIRST_ID

--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -37,6 +37,7 @@ class SysTrayIcon(object):
         self._hover_text = hover_text
         self._on_quit = on_quit
 
+        self._menu = None
         self._set_menu_options(menu_options)
 
         window_class_name = window_class_name or ("SysTrayIconPy-%s" % (str(uuid.uuid4())))
@@ -54,7 +55,6 @@ class SysTrayIcon(object):
         self._hicon = 0
         self._hinst = None
         self._window_class = None
-        self._menu = None
         self._register_class()
 
     def __enter__(self):

--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -208,9 +208,13 @@ class SysTrayIcon(object):
         nid = NotifyData(self._hwnd, 0)
         Shell_NotifyIcon(NIM_DELETE, ctypes.byref(nid))
         PostQuitMessage(0)  # Terminate the app.
-        # TODO * release self._menu with DestroyMenu and reset the memeber
-        #      * release self._hicon with DestoryIcon and reset the member
-        #      * release loaded menu icons (loaded in _load_menu_icon) with DeleteObject
+        if self._menu is not None:
+            DestroyMenu(self._menu)
+            self._menu = None
+        if self._hicon != 0:
+            DestroyIcon(self._hicon)
+            self._hicon = 0
+        # TODO * release loaded menu icons (loaded in _load_menu_icon) with DeleteObject
         #        (we don't keep those objects anywhere now)
         self._hwnd = None
         self._notify_id = None

--- a/src/infi/systray/win32_adapter.py
+++ b/src/infi/systray/win32_adapter.py
@@ -35,6 +35,7 @@ TranslateMessage = ctypes.windll.user32.TranslateMessage
 DispatchMessage = ctypes.windll.user32.DispatchMessageA
 Shell_NotifyIcon = ctypes.windll.shell32.Shell_NotifyIcon
 DestroyIcon = ctypes.windll.user32.DestroyIcon
+DestroyMenu = ctypes.windll.user32.DestroyMenu
 
 NIM_ADD = 0
 NIM_MODIFY = 1


### PR DESCRIPTION
This adds a new parameter to the update function such that the menu_options can be updated the same way that the icon/hover text can be updated. I wanted this functionality for an app where an item in the right click menu changes based on state, and this pull request adds this functionality.

I also tried to avoid duplicated code and keep the menu creation code in one central function "_set_menu_options"