### PR TITLE
Fix for runtime error when shutting down thread.

### DIFF
--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -120,7 +120,12 @@ class SysTrayIcon(object):
         if not self._hwnd:
             return      # not started
         PostMessage(self._hwnd, WM_CLOSE, 0, 0)
-        self._message_loop_thread.join()
+
+        try:
+            self._message_loop_thread.join()
+        except RunTimeError as err:
+            if err == "cannot join current thread":
+                return
 
     def update(self, icon=None, hover_text=None):
         """ update icon image and/or hover text """

--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -123,7 +123,7 @@ class SysTrayIcon(object):
 
         try:
             self._message_loop_thread.join()
-        except RunTimeError as err:
+        except RuntimeError as err:
             if err == "cannot join current thread":
                 return
 

--- a/src/infi/systray/traybar.py
+++ b/src/infi/systray/traybar.py
@@ -123,9 +123,10 @@ class SysTrayIcon(object):
 
         try:
             self._message_loop_thread.join()
+            self._hwnd = None
         except RuntimeError as err:
             if err == "cannot join current thread":
-                return
+                self._hwnd = None
 
     def update(self, icon=None, hover_text=None):
         """ update icon image and/or hover text """
@@ -135,6 +136,12 @@ class SysTrayIcon(object):
         if hover_text:
             self._hover_text = hover_text
         self._refresh_icon()
+
+    def isAlive(self):
+        result = True
+        if self._hwnd == None:
+            result = False
+        return result
 
     def _add_ids_to_menu_options(self, menu_options):
         result = []


### PR DESCRIPTION
From documentation: join() raises a RuntimeError if an attempt is made to join the current thread as that would cause a deadlock. It is also an error to join() a thread before it has been started and attempts to do so raises the same exception.

https://docs.python.org/2/library/threading.html

I'm assuming that I'm getting the RuntimeError because the thread dies before .join() is called. This *might* be a safe way of handling the runtime error this throws.